### PR TITLE
v0.4.6

### DIFF
--- a/docs/classes/apiconsoleapp.html
+++ b/docs/classes/apiconsoleapp.html
@@ -142,7 +142,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides ApiApp.__constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/aa6ba4b/src/ApiConsoleApp.ts#L32">ApiConsoleApp.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src/ApiConsoleApp.ts#L32">ApiConsoleApp.ts:32</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -171,7 +171,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ApiApp.apiServer</p>
 						<ul>
-							<li>Defined in /home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:26</li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L26">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ApiApp.appConfig</p>
 						<ul>
-							<li>Defined in /home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:24</li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L24">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ApiApp.appContainer</p>
 						<ul>
-							<li>Defined in /home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:25</li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L25">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -204,7 +204,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ApiApp.controllersPath</p>
 						<ul>
-							<li>Defined in /home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:23</li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L23">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -214,7 +214,7 @@
 					<div class="tsd-signature tsd-kind-icon">express<wbr>App<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Application</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/aa6ba4b/src/ApiConsoleApp.ts#L30">ApiConsoleApp.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src/ApiConsoleApp.ts#L30">ApiConsoleApp.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -225,7 +225,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ApiApp.initialised</p>
 						<ul>
-							<li>Defined in /home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:29</li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L29">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -236,7 +236,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ApiApp.logFactory</p>
 						<ul>
-							<li>Defined in /home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:27</li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L27">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -247,7 +247,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ApiApp.logger</p>
 						<ul>
-							<li>Defined in /home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:28</li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L28">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -258,7 +258,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ApiApp.middlewareRegistry</p>
 						<ul>
-							<li>Defined in /home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:30</li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L30">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -276,7 +276,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from ApiApp.configureApi</p>
 								<ul>
-									<li>Defined in /home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:51</li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L51">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:51</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -326,7 +326,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from ApiApp.configureApp</p>
 								<ul>
-									<li>Defined in /home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:45</li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L45">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:45</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -379,7 +379,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from ApiApp.initialiseControllers</p>
 								<ul>
-									<li>Defined in /home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:64</li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L64">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:64</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -402,7 +402,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides ApiApp.run</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/aa6ba4b/src/ApiConsoleApp.ts#L42">ApiConsoleApp.ts:42</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src/ApiConsoleApp.ts#L42">ApiConsoleApp.ts:42</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -428,7 +428,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/aa6ba4b/src/ApiConsoleApp.ts#L51">ApiConsoleApp.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src/ApiConsoleApp.ts#L51">ApiConsoleApp.ts:51</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -459,7 +459,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/aa6ba4b/src/ApiConsoleApp.ts#L134">ApiConsoleApp.ts:134</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src/ApiConsoleApp.ts#L134">ApiConsoleApp.ts:134</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ts-lambda-api-local",
   "description": "Test ts-lambda-api API's locally using express.",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/djfdyuruiry/ts-lambda-api-local.git"
@@ -10,7 +10,7 @@
     "build": "yarn run lint && rm -rf dist && tsc && yarn docs",
     "build-all": "yarn run install-with-audit && yarn run build && yarn run build-tests",
     "build-tests": "rm -rf ./tests/js && tsc -p ./tests",
-    "docs": "rm -rf ./docs && typedoc --mode file --excludePrivate --out ./docs",
+    "docs": "rm -rf ./docs && typedoc --mode file --excludePrivate --sourcefile-url-prefix https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src/ --out ./docs",
     "clean-install": "rm -rf node_modules && yarn install-with-audit",
     "install-with-audit": "yarn install --audit && yarn audit",
     "lint": "tslint 'src/**/*.ts'",
@@ -45,7 +45,7 @@
     "cors": "^2.8.5",
     "express": "^4.16.4",
     "swagger-ui-express": "^4.0.2",
-    "ts-lambda-api": "^0.4.3"
+    "ts-lambda-api": "^0.4.6"
   },
   "devDependencies": {
     "@types/body-parser": "^1.17.0",
@@ -66,6 +66,7 @@
     "tslint": "^5.13.0",
     "typed-rest-client": "^1.1.2",
     "typedoc": "^0.14.2",
+    "typedoc-plugin-sourcefile-url": "^1.0.4",
     "typescript": "^3.3.3"
   }
 }

--- a/tests/src/test-controllers/EchoController.ts
+++ b/tests/src/test-controllers/EchoController.ts
@@ -2,7 +2,7 @@ import * as path from "path"
 
 import { injectable } from "inversify";
 import { Response } from "lambda-api";
-import { fromBody, header, produces, queryParam, response, GET, POST, Controller } from "ts-lambda-api";
+import { body, header, produces, queryParam, rawBody, response, GET, POST, Controller } from "ts-lambda-api";
 
 import { Message } from "./Message";
 
@@ -25,22 +25,22 @@ export class EchoController extends Controller {
     }
 
     @POST("/echo")
-    public echo(@fromBody message: Message, @response response: Response): Message {
+    public echo(@body message: Message, @response response: Response): Message {
         response.status(201)
 
         return message
     }
 
     @POST("/echo-body")
-    public echoBody(@fromBody message: any): Message {
+    public echoBody(@body message: any): Message {
         return message
     }
 
     @produces("application/octet-stream")
     @POST("/echo-binary-body")
-    public echoBinaryBody(@header("content-type") contentType: string) {
+    public echoBinaryBody(@rawBody body: Buffer, @header("content-type") contentType: string) {
         this.response
             .header("content-type", contentType)
-            .sendFile(Buffer.from(this.request.rawBody, 'base64'))
+            .sendFile(body)
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,10 +2046,10 @@ trim@0.0.1:
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
   integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
 
-ts-lambda-api@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/ts-lambda-api/-/ts-lambda-api-0.4.3.tgz#f93ab5abdfc31960a44869178fac592271c48f17"
-  integrity sha512-qmP0RDVjN50QzlKOluxqx/pLabQSAdsa6clekaxM+adkOWpahwc9wesQNm2CQTQxLxqAFn5lUBjoPBVm+OiG0g==
+ts-lambda-api@^0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/ts-lambda-api/-/ts-lambda-api-0.4.6.tgz#191e3e925aa90151f92240cba59ca0aec3032362"
+  integrity sha512-Zgzk6dnq4mGqre1qpylzMwZwp2NUv1Ef/l4hnYkI+gOrIglvqD2IQ3AB6Q1FOLEspN6gixUKII1nWrsA3OYbaw==
   dependencies:
     "@types/aws-lambda" "^8.10.19"
     fast-json-patch "^2.0.7"
@@ -2130,6 +2130,11 @@ typedoc-default-themes@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
   integrity sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=
+
+typedoc-plugin-sourcefile-url@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-sourcefile-url/-/typedoc-plugin-sourcefile-url-1.0.4.tgz#a4054b834414eb62434dbe809eb689682b486002"
+  integrity sha512-vydiILnDDyOcmeLrOiigYchOuy/1SJm8dG2nznTizNPxv17HUVdLVLLscki1wleQQPc+Yd+PzNCjreXiAdL4ug==
 
 typedoc@^0.14.2:
   version "0.14.2"


### PR DESCRIPTION
- Updating `ts-lambda-api` to v0.4.6
- Locking typedoc URLs to master