### PR TITLE
v0.6.1

### DIFF
--- a/docs/classes/apiconsoleapp.html
+++ b/docs/classes/apiconsoleapp.html
@@ -142,7 +142,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides ApiApp.__constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src/ApiConsoleApp.ts#L32">ApiConsoleApp.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/srcApiConsoleApp.ts#L32">ApiConsoleApp.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -179,7 +179,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ApiApp.apiServer</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L26">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts">ApiApp.ts</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -190,7 +190,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ApiApp.appConfig</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L24">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts">ApiApp.ts</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -201,7 +201,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ApiApp.appContainer</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L25">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts">ApiApp.ts</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -212,7 +212,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ApiApp.controllersPath</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L23">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts">ApiApp.ts</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -222,7 +222,7 @@
 					<div class="tsd-signature tsd-kind-icon">express<wbr>App<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Application</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src/ApiConsoleApp.ts#L30">ApiConsoleApp.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/srcApiConsoleApp.ts#L30">ApiConsoleApp.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -233,7 +233,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ApiApp.initialised</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L29">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:29</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts">ApiApp.ts</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -244,7 +244,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ApiApp.logFactory</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L27">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts">ApiApp.ts</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -255,7 +255,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ApiApp.logger</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L28">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts">ApiApp.ts</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -266,7 +266,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from ApiApp.middlewareRegistry</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L30">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts">ApiApp.ts</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -284,7 +284,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from ApiApp.configureApi</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L51">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts">ApiApp.ts</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -334,7 +334,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from ApiApp.configureApp</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L45">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:45</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts">ApiApp.ts</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -387,7 +387,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from ApiApp.initialiseControllers</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src//home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts#L64">/home/matthew/src/ts/ts-lambda-api-local/node_modules/ts-lambda-api/dist/ApiApp.d.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src/ApiApp.ts">ApiApp.ts</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -410,7 +410,7 @@
 							<aside class="tsd-sources">
 								<p>Overrides ApiApp.run</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src/ApiConsoleApp.ts#L66">ApiConsoleApp.ts:66</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/srcApiConsoleApp.ts#L66">ApiConsoleApp.ts:66</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -436,7 +436,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src/ApiConsoleApp.ts#L75">ApiConsoleApp.ts:75</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/srcApiConsoleApp.ts#L75">ApiConsoleApp.ts:75</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -467,7 +467,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src/ApiConsoleApp.ts#L158">ApiConsoleApp.ts:158</a></li>
+									<li>Defined in <a href="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/srcApiConsoleApp.ts#L158">ApiConsoleApp.ts:158</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ts-lambda-api-local",
   "description": "Test ts-lambda-api API's locally using express.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/djfdyuruiry/ts-lambda-api-local.git"
@@ -11,11 +11,11 @@
     "build-all": "yarn clean-install && yarn build && yarn build-tests",
     "build-tests": "rm -rf ./tests/js && tsc -p ./tests",
     "clean-install": "rm -rf node_modules && yarn install && yarn improved-audit",
-    "docs": "rm -rf ./docs && typedoc --mode file --excludePrivate --sourcefile-url-prefix https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src/ --out ./docs",
+    "docs": "./scripts/generateDocs.sh",
     "improved-audit": "improved-yarn-audit -e $(cat .audit-exceptions)",
     "lint": "tslint 'src/**/*.ts'",
     "shell": "$SHELL",
-    "test": "yarn build-all && scripts/runTests.sh",
+    "test": "yarn build-all && ./scripts/runTests.sh",
     "test-app": "yarn build-all && node ./tests/js/test-components/TestApp.js"
   },
   "main": "dist/ts-lambda-api-local.js",
@@ -44,7 +44,7 @@
     "cors": "^2.8.5",
     "express": "^4.17.0",
     "swagger-ui-express": "^4.0.4",
-    "ts-lambda-api": "^0.6.0"
+    "ts-lambda-api": "^0.6.1"
   },
   "devDependencies": {
     "@types/body-parser": "^1.17.0",

--- a/scripts/generateDocs.sh
+++ b/scripts/generateDocs.sh
@@ -1,0 +1,30 @@
+#! /usr/bin/env bash
+set -e
+
+projectGithubUrl="https://github.com/djfdyuruiry/ts-lambda-api-local/blob/master/src"
+tlaGithubUrl="https://github.com/djfdyuruiry/ts-lambda-api/blob/master/src"
+docHtmlPath="./docs/classes/apiconsoleapp.html"
+projectPath="$(pwd)"
+
+function cleanUpDocUrls() {
+    sed -i "s^${projectGithubUrl}${projectPath}/node_modules/ts-lambda-api/dist/^${tlaGithubUrl}/^" "${docHtmlPath}"
+    sed -i "s^${projectPath}/node_modules/ts-lambda-api/dist/^^" "${docHtmlPath}"
+    sed -E -i "s/.d.ts:[0-9]+/.ts/" "${docHtmlPath}"
+    sed -E -i "s/.d.ts#L[0-9]+/.ts/" "${docHtmlPath}"
+}
+
+function generateTypedoc() {
+    rm -rf ./docs
+
+    typedoc --mode file \
+        --excludePrivate \
+        --sourcefile-url-prefix "${projectGithubUrl}" \
+        --out ./docs
+}
+
+function generateDocs() {
+    generateTypedoc
+    cleanUpDocUrls
+}
+
+generateDocs

--- a/yarn.lock
+++ b/yarn.lock
@@ -2054,10 +2054,10 @@ trim@0.0.1:
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
   integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
 
-ts-lambda-api@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/ts-lambda-api/-/ts-lambda-api-0.6.0.tgz#5d627acd3d4f8861e690b79841baf0c009c2211b"
-  integrity sha512-FcHrN4ThUfmerFGwMDW9ARzjMImxuNzqA2jC3XhBMQC4Kl8rbOCHFlKF+k1UBCSH+SOuqgkVMfTgUFZWXb5uRA==
+ts-lambda-api@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/ts-lambda-api/-/ts-lambda-api-0.6.1.tgz#77c5834ff8af9df9f4e3a1a455693e04fad2fc11"
+  integrity sha512-4kB0VQ6LeUDCJx+K/D3xQUXgi8VjWrBbF0W3QaSn84tkzbkQn2A1mMNlEw4k+VKrPh9jWSYLiYRw0ud5NK5dQA==
   dependencies:
     "@types/aws-lambda" "^8.10.19"
     fast-json-patch "^2.0.7"


### PR DESCRIPTION
- Upgrading `ts-lambda-api` to v0.6.1 
- Fixing issues with docs including invalid paths for `ts-lambda-api`